### PR TITLE
feat: new OLED Display settings (rotation, power)

### DIFF
--- a/indoor-floor-level-tracker/firmware/src/main.cpp
+++ b/indoor-floor-level-tracker/firmware/src/main.cpp
@@ -6,6 +6,13 @@
 
 // Uncomment to use a connected SSD1306 Display
 #define USE_DISPLAY
+#define DISPLAY_ROTATE_180
+
+// Uncomment to give the OLED Display power from digital MCU pins.
+// Safe for 0.91 Inch I2C OLED Display on Notecarrier-F + Blues Swan.
+// UNSAFE if your display takes more amps than your microcontroller can supply.
+// #define DISPLAY_POWER_PIN 5
+// #define DISPLAY_GROUND_PIN 6
 
 #ifdef USE_DISPLAY
 #include <Adafruit_GFX.h>
@@ -75,6 +82,14 @@ void setup() {
   notecard.begin();
 
 #ifdef USE_DISPLAY
+#ifdef DISPLAY_POWER_PIN
+  pinMode(DISPLAY_POWER_PIN, OUTPUT);
+  digitalWrite(DISPLAY_POWER_PIN, HIGH);
+#endif
+#ifdef DISPLAY_GROUND_PIN
+  pinMode(DISPLAY_GROUND_PIN, OUTPUT);
+  digitalWrite(DISPLAY_GROUND_PIN, LOW);
+#endif
   display.begin(SSD1306_SWITCHCAPVCC, 0x3C);
   serialDebugOut.println("OLED connected...");
 #endif
@@ -109,7 +124,9 @@ void setup() {
   display.display();
 
   // text display tests
+#ifdef DISPLAY_ROTATE_180
   display.setRotation(2);
+#endif
   display.setTextSize(1);
   display.setTextColor(SSD1306_WHITE);
   display.setCursor(0, 0);


### PR DESCRIPTION
# Problem Context

- I wanted to rotate the OLED display on my device.
- I wanted to power the OLED display through the analog pins 5+6 on my Notecarrier-F

## Solution

- Add compiler `#define`s for rotation and for using mcu pins for power. 

```cpp
#define DISPLAY_ROTATE_180

// Uncomment to give the OLED Display power from digital MCU pins.
// Safe for 0.91 Inch I2C OLED Display on Notecarrier-F + Blues Swan.
// UNSAFE if your display takes more amps than your microcontroller can supply.
#define DISPLAY_POWER_PIN 5
#define DISPLAY_GROUND_PIN 6
```

### Review Tips

- First commit is just code formatting (clang formatter was closest to what we already had)
- Second commit is substantive changes.

![image](https://user-images.githubusercontent.com/22032748/191804591-77ad7feb-ebb5-4e2a-8eb8-7bd5f6425440.png)
