### PR TITLE
Make several improvements to valve-monitor firmware. 

### DIFF
--- a/valve-monitor/firmware/README.md
+++ b/valve-monitor/firmware/README.md
@@ -1,0 +1,41 @@
+# Flow Rate Sensor and Valve Controller
+
+This directory contains Arduino-based firmware for a flow rate measurement
+utility with optional valve control support.
+
+## Requirements
+
+- Visual Studio Code with the [PlatformIO IDE](https://platformio.org/platformio-ide)
+installed.
+- [Notecard](https://blues.io/products/notecard/).
+- [Swan MCU](https://blues.io/products/swan/).
+- [Notecarrier F](https://blues.io/products/notecarrier/notecarrier-f/).
+- Male to male jumper wires.
+- A micro USB data cable.
+
+## Setup
+
+- [Plug the Notecard into the Notecarrier F](https://dev.blues.io/quickstart/notecard-quickstart/notecard-and-notecarrier-f/).
+- Plug the Swan into the Feather-compatible headers on the Notecarrier.
+- Connect the ATTN and F_D13 pins on the Notecarrier.
+- Connect the F_D10 pin of the Notecarrier to your solenoid valve's control pin.
+- Connect the F_D6 pin of the Notecarrier to the signal pin of your flow rate
+meter.
+- Connect the Swan to your development machine with the micro USB cable.
+- Open Visual Studio Code and navigate to the PlatformIO menu using the icon
+on the leftmost side.
+- Select "Open" and open valve-monitor/firmware.
+- Edit main.cpp so to define a valid product UID:
+
+```C
+// Replace with your product UID.
+// #define PRODUCT_UID "com.my-company.my-name:my-project"
+```
+
+- In the Project Tasks pane of the PlatformIO view, click Build.
+- Hold down the BOOT button on the Swan, press and release the RST button, and
+release the BOOT button. The Swan is now ready to receive the firmware image
+from PlatformIO via the micro USB cable.
+- In the Project Tasks pane of the PlatformIO view, click Upload.
+- At the bottom of the VS Code window, click the tiny plug icon to open the
+serial console. You should see messages from the Swan being logged.

--- a/valve-monitor/firmware/src/main.cpp
+++ b/valve-monitor/firmware/src/main.cpp
@@ -21,11 +21,13 @@
 #define ENV_POLL_MS (5 * 1000)
 // After triggering an alarm, raise the alarm every 30 seconds after that.
 #define ALARM_REFRESH_MS (30 * 1000)
-// Calculate the flow rate every 200 ms. We want to allow a little time between
+// Calculate the flow rate every 500 ms. We want to allow a little time between
 // measurements for the sensor's signal line to pulse. If we make this interval
 // too small, its possible we won't have enough sensor data (i.e. pulses) to
 // produce an accurate flow rate measurement.
-#define FLOW_CALC_INTERVAL_MS 200
+#define FLOW_CALC_INTERVAL_MS 500
+
+#define LEAK_THRESHOLD 6
 
 // Define USE_VALVE to compile in valve control support. If not defined, it's
 // turned on by default.
@@ -53,6 +55,7 @@ struct AppState {
     uint32_t flowRate;
     uint32_t flowRateAlarmMin;
     uint32_t flowRateAlarmMax;
+    uint32_t leakCount;
     volatile bool attnTriggered;
     bool valveOpen;
     bool ackValveCmd;
@@ -100,6 +103,9 @@ void valveToggle()
         // mechanism isn't needed.
         state.valveOpenedMs = millis();
         digitalWrite(VALVE_OPEN_PIN, HIGH);
+        // Clear leak counter. By definition, we can't have a leak if the valve
+        // is open.
+        state.leakCount = 0;
     }
 
     state.valveOpen = !state.valveOpen;
@@ -121,7 +127,6 @@ void handleValveCmd(char *cmd)
     else if (!strcmp(cmd, "close")) {
         notecard.logDebug("Received valve close cmd.\n");
         if (state.valveOpen) {
-            state.flowMeterPulseCount = 0;
             valveToggle();
         }
         else {
@@ -135,13 +140,18 @@ void handleValveCmd(char *cmd)
     state.ackValveCmd = 1;
 }
 
-// Publish the system status (flow rate, valve state) via a note to the
-// specified Notefile.
-void publishSystemStatus(uint32_t flowRate, const char *file)
+// Publish the system status (flow rate, valve state). If alarmReason is not
+// NULL, attach the reason to the outbound note and send it to alarm.qo.
+// Otherwise, send the note to data.qo.
+void publishSystemStatus(uint32_t flowRate, const char *alarmReason)
 {
-    if (file == NULL) {
-        notecard.logDebug("publishSystemStatus called with NULL file.\n");
-        return;
+    const char *file;
+
+    if (alarmReason == NULL) {
+        file = "data.qo";
+    }
+    else {
+        file = "alarm.qo";
     }
 
     J *req = notecard.newRequest("note.add");
@@ -161,6 +171,10 @@ void publishSystemStatus(uint32_t flowRate, const char *file)
                 JAddStringToObject(body, "valve_state", "closed");
             }
         #endif // USE_VALVE
+
+            if (alarmReason != NULL) {
+                JAddStringToObject(body, "reason", alarmReason);
+            }
 
             JAddStringToObject(body, "app", "nf9");
             JAddItemToObject(req, "body", body);
@@ -232,10 +246,15 @@ bool fetchEnvVars()
             if (body != NULL) {
                 char *valueStr = JGetString(body, "monitor_interval");
                 float value;
+                char *endPtr;
 
                 if (valueStr != NULL) {
-                    value = atof(valueStr);
-                    if (value != 0.0) {
+                    value = strtof(valueStr, &endPtr);
+                    if ((value == 0 && valueStr == endPtr) || value < 0) {
+                        notecard.logDebugf("Failed to convert %s to positive "
+                            "float for monitor interval.\n", valueStr);
+                    }
+                    else {
                         state.monitorIntervalMs = (uint32_t)(value * 1000);
                         updated = true;
                         notecard.logDebugf("Monitor interval set to %u ms.\n",
@@ -245,8 +264,12 @@ bool fetchEnvVars()
 
                 valueStr = JGetString(body, "flow_rate_alarm_threshold_min");
                 if (valueStr != NULL) {
-                    value = atof(valueStr);
-                    if (value != 0.0) {
+                    value = strtof(valueStr, &endPtr);
+                    if ((value == 0 && valueStr == endPtr) || value < 0) {
+                        notecard.logDebugf("Failed to convert %s to positive "
+                            "float for flow rate min.\n", valueStr);
+                    }
+                    else {
                         state.flowRateAlarmMin = value;
                         updated = true;
                         notecard.logDebugf("Flow rate min set to %u mL/min.\n",
@@ -256,8 +279,12 @@ bool fetchEnvVars()
 
                 valueStr = JGetString(body, "flow_rate_alarm_threshold_max");
                 if (valueStr != NULL) {
-                    value = atof(valueStr);
-                    if (value != 0.0) {
+                    value = strtof(valueStr, &endPtr);
+                    if ((value == 0 && valueStr == endPtr) || value < 0) {
+                        notecard.logDebugf("Failed to convert %s to positive "
+                            "float for flow rate max.\n", valueStr);
+                    }
+                    else {
                         state.flowRateAlarmMax = value;
                         updated = true;
                         notecard.logDebugf("Flow rate max set to %u mL/min.\n",
@@ -378,48 +405,32 @@ uint32_t calculateFlowRate(uint32_t currentMs)
            (currentMs - state.lastFlowRateCalcMs);
 }
 
-void alarm(float flowRate)
-{
-    J *req = notecard.newRequest("note.add");
-
-    if (req != NULL) {
-        JAddBoolToObject(req, "sync", true);
-        JAddStringToObject(req, "file", "alarm.qo");
-
-        J *body = JCreateObject();
-        if (body != NULL) {
-            JAddNumberToObject(body, "flow_rate", flowRate);
-            JAddBoolToObject(body, "valve_state", true);
-            JAddStringToObject(body, "app", "nf9");
-            JAddItemToObject(req, "body", body);
-
-            notecard.sendRequest(req);
-        }
-        else {
-             notecard.logDebug("Failed to create body for alarm note.\n");
-        }
-    }
-    else {
-        notecard.logDebug("Failed to create note.add request alarm note.\n");
-    }
-}
-
 void checkAlarm(float flowRate)
 {
-    bool flowRateOutOfBounds = state.valveOpen &&
-                               (flowRate < state.flowRateAlarmMin ||
-                                flowRate > state.flowRateAlarmMax);
-    bool leaking = !state.valveOpen && flowRate > 0;
+    bool flowRateHigh = state.valveOpen && flowRate > state.flowRateAlarmMax;
+    bool flowRateLow = state.valveOpen && flowRate < state.flowRateAlarmMin;
+    bool leaking = state.leakCount >= LEAK_THRESHOLD;
 
-    if (flowRateOutOfBounds || leaking) {
-        uint32_t currentMs = millis();
-
+    if (flowRateHigh || flowRateLow || leaking) {
         // After the initial alarm for an event, only resend the alarm note
         // every ALARM_REFRESH_MS, to avoid flooding Notehub.
+        uint32_t currentMs = millis();
         if (state.lastAlarmMs == 0 || (currentMs - state.lastAlarmMs) >=
             ALARM_REFRESH_MS) {
             state.lastAlarmMs = currentMs;
-            publishSystemStatus(flowRate, "alarm.qo");
+
+            const char* reason;
+            if (flowRateHigh) {
+                reason = "high";
+            }
+            else if (flowRateLow) {
+                reason = "low";
+            }
+            else {
+                reason = "leak";
+            }
+
+            publishSystemStatus(flowRate, reason);
         }
     }
     else {
@@ -429,13 +440,84 @@ void checkAlarm(float flowRate)
 
 void loop()
 {
+    uint32_t currentMs;
+
+#ifdef USE_VALVE
+    if (state.valveOpen) {
+        currentMs = millis();
+        if (currentMs - state.valveOpenedMs >= MAX_OPEN_MS) {
+            notecard.logDebugf("Valve open for max %u ms, closing to "
+                "prevent overheating.\n", MAX_OPEN_MS);
+            valveToggle();
+        }
+    }
+
+    if (state.attnTriggered) {
+        // Re-arm the ATTN interrupt.
+        attnArm();
+
+        // Process all pending inbound requests.
+        while (true) {
+            // Pop the next available note from data.qi.
+            J *req = notecard.newRequest("note.get");
+            JAddStringToObject(req, "file", "data.qi");
+            JAddBoolToObject(req, "delete", true);
+            J *rsp = notecard.requestAndResponse(req);
+            if (rsp != NULL) {
+
+                // If an error is returned, this means that no response is
+                // pending. Note that it's expected that this might return
+                // either a "note does not exist" error if there are no pending
+                // inbound notes, or a "file does not exist" error if the
+                // inbound queue hasn't yet been created on the service.
+                if (notecard.responseError(rsp)) {
+                    notecard.deleteResponse(rsp);
+                    break;
+                }
+
+                // Get the note's body
+                J *body = JGetObject(rsp, "body");
+                if (body != NULL) {
+                    char *cmd = JGetString(body, "state");
+                    if (cmd != NULL && strlen(cmd) != 0) {
+                        handleValveCmd(cmd);
+                    }
+                    else {
+                        notecard.logDebug("Unable to get valve command from note."
+                            "\n");
+                    }
+                }
+                else {
+                    notecard.logDebug("Note body was NULL.\n");
+                }
+            }
+
+            notecard.deleteResponse(rsp);
+        }
+    }
+#endif // USE_VALVE
+
     updateEnvVars();
 
-    uint32_t currentMs = millis();
+    currentMs = millis();
     if (currentMs - state.lastFlowRateCalcMs >= FLOW_CALC_INTERVAL_MS) {
         state.flowRate = calculateFlowRate(currentMs);
         state.lastFlowRateCalcMs = currentMs;
         state.flowMeterPulseCount = 0;
+
+        if (!state.valveOpen) {
+            // If the valve is closed and flow is detected, increment the
+            // leak counter. If a leak is detected on LEAK_THRESHOLD or more
+            // consecutive measurements, a leak alarm will be published. This
+            // filter prevents spurious leak alarms shortly after the valve is
+            // closed while the flow meter's spinner is still slowing down.
+            if (state.flowRate > 0) {
+                ++state.leakCount;
+            }
+            else {
+                state.leakCount = 0;
+            }
+        }
     }
     
     checkAlarm(state.flowRate);
@@ -448,70 +530,10 @@ void loop()
     if (state.ackValveCmd ||
         (currentMs - state.monitorLastUpdateMs >= state.monitorIntervalMs)) {
         state.monitorLastUpdateMs = currentMs;
-        publishSystemStatus(state.flowRate, "data.qo");
+        publishSystemStatus(state.flowRate, NULL);
 
         if (state.ackValveCmd) {
             state.ackValveCmd = 0;
         }
     }
-
-// All the code below is for valve control, so only compile it in if USE_VALVE
-// is defined.
-#ifdef USE_VALVE
-    if (state.valveOpen) {
-        currentMs = millis();
-        if (currentMs - state.valveOpenedMs >= MAX_OPEN_MS) {
-            notecard.logDebugf("Valve open for max %u ms, closing to "
-                "prevent overheating.\n", MAX_OPEN_MS);
-            valveToggle();
-        }
-    }
-
-    // If the ATTN interrupt hasn't occurred, nothing to do.
-    if (!state.attnTriggered) {
-        return;
-    }
-
-    // Re-arm the ATTN interrupt.
-    attnArm();
-
-    // Process all pending inbound requests.
-    while (true) {
-        // Pop the next available note from data.qi.
-        J *req = notecard.newRequest("note.get");
-        JAddStringToObject(req, "file", "data.qi");
-        JAddBoolToObject(req, "delete", true);
-        J *rsp = notecard.requestAndResponse(req);
-        if (rsp != NULL) {
-
-            // If an error is returned, this means that no response is pending.
-            // Note that it's expected that this might return either a "note
-            // does not exist" error if there are no pending inbound notes, or a
-            // "file does not exist" error if the inbound queue hasn't yet been
-            // created on the service.
-            if (notecard.responseError(rsp)) {
-                notecard.deleteResponse(rsp);
-                break;
-            }
-
-            // Get the note's body
-            J *body = JGetObject(rsp, "body");
-            if (body != NULL) {
-                char *cmd = JGetString(body, "state");
-                if (cmd != NULL && strlen(cmd) != 0) {
-                    handleValveCmd(cmd);
-                }
-                else {
-                    notecard.logDebug("Unable to get valve command from note."
-                        "\n");
-                }
-            }
-            else {
-                notecard.logDebug("Note body was NULL.\n");
-            }
-        }
-
-        notecard.deleteResponse(rsp);
-    }
-#endif // USE_VALVE
 }

--- a/valve-monitor/firmware/src/main.cpp
+++ b/valve-monitor/firmware/src/main.cpp
@@ -392,8 +392,8 @@ void setup()
 
     // Default values.
     state.monitorIntervalMs = 10000; // 10 seconds
-    state.flowRateAlarmMin = 10;
-    state.flowRateAlarmMax = 100;
+    state.flowRateAlarmMin = 500;
+    state.flowRateAlarmMax = 1500;
 
     fetchEnvVars();
 }


### PR DESCRIPTION
- Remove my specific PRODUCT_UID definition.
- Consolidate the alarm and status publishing logic into a single function, as the format of notes for both is the same, now.
- Only configure the valve control pin if USE_VALVE is defined.
- Add leak detection logic and publish an alarm note if a leak is detected.
- Increase time between flow rate calculations from 200 to 500 ms.
- Give the flow rate meter's spinner time to stop spinning after closing the
valve to prevent spurious alarms. I implemented this by requiring 6 consecutive
detections of flow while the valve is closed before a leak alarm goes out.
- Add support for an alarm reason field. Valid reasons are high, low, and leak.
- Use strtof instead of atof when parsing environment variable values. atof is
tricky because it returns 0 on errors, which is problematic if the value passed
in was in fact 0.
- Get rid of dead alarm function.
- Rearrange the main loop so that the valve logic comes first.