### PR TITLE
chore: note the usage of consumption credits, and where to update refresh interval

### DIFF
--- a/indoor-floor-level-tracker/web-app/README.md
+++ b/indoor-floor-level-tracker/web-app/README.md
@@ -163,3 +163,8 @@ the change.
 
 > **NOTE**: Changes to `.env` are **not** automatically reloaded, and require you
 to stop the `yarn dev` with `ctrl+c` and to start `yarn dev` back up.
+
+The web app uses the [Notehub API](https://dev.blues.io/guides-and-tutorials/using-the-notehub-api/) to retrieve event data, which consumes [Notehub consumption credits](https://blues.io/pricing/).
+You can change how frequently the app refreshes data from Notehub by altering
+the `MS_REFETCH_INTERVAL` constant in the [`src/pages/index.tsx`](/src/pages/index.tsx)
+file.

--- a/indoor-floor-level-tracker/web-app/src/pages/index.tsx
+++ b/indoor-floor-level-tracker/web-app/src/pages/index.tsx
@@ -24,7 +24,12 @@ type HomeData = {
 
 const Home: NextPage<HomeData> = ({ fleetTrackerConfig, error }) => {
   const infoMessage = "Deploy message";
-  const MS_REFETCH_INTERVAL = 10000;
+
+  // How often to refetch data from Notehub (in milliseconds). Note that
+  // reading data with the Notehub API uses one consumption credit per event
+  // (see https://blues.io/pricing/).
+  const MS_REFETCH_INTERVAL = 60 * 1000;
+
   const [isLoading, setIsLoading] = useState<boolean>(false);
   const [isErrored, setIsErrored] = useState<boolean>(false);
   const [errorMessage, setErrorMessage] = useState<string>("");


### PR DESCRIPTION
I had meant to do this at the end of NF1 but totally forgot. This PR turns the refresh interval of the web app down to once a minute (instead of every 10 seconds), and also adds a note of where users can tweak the interval.