### PR TITLE
fix: only take the first alarm by date descending

### DIFF
--- a/valve-monitor/web-app/src/api-client/valveDevices.ts
+++ b/valve-monitor/web-app/src/api-client/valveDevices.ts
@@ -13,7 +13,8 @@ export async function getValveMonitorDeviceData(): Promise<
   const endpoint = services().getUrlManager().getValveMonitorDeviceData();
   const response: AxiosResponse =
     await axios.get<GetValveMonitorDeviceResponse>(endpoint);
-  return response.data.valveMonitorDevices;
+  const devices = response.data.valveMonitorDevices as ValveMonitorDevice[];
+  return devices.sort((a, b) => a.name.localeCompare(b.name));
 }
 
 async function updateDevice(deviceUID: string, deviceEnvVarToUpdate: object) {

--- a/valve-monitor/web-app/src/pages/api/clear-alarms.ts
+++ b/valve-monitor/web-app/src/pages/api/clear-alarms.ts
@@ -1,4 +1,5 @@
 // Next.js API route support: https://nextjs.org/docs/api-routes/introduction
+import { StatusCodes } from "http-status-codes";
 import type { NextApiRequest, NextApiResponse } from "next";
 import { ErrorWithCause } from "pony-cause";
 import { HTTP_STATUS } from "../../constants/http";
@@ -18,8 +19,7 @@ export default async function clearAlarmsHandler(
         });
       }
 
-      // res.status(StatusCodes.OK).json({});
-      res.status(500).json({});
+      res.status(StatusCodes.OK).json({});
 
       break;
     default:

--- a/valve-monitor/web-app/src/pages/index.tsx
+++ b/valve-monitor/web-app/src/pages/index.tsx
@@ -21,7 +21,8 @@ type HomeData = {
 };
 
 const Home: NextPage<HomeData> = ({ valveMonitorConfig, err }) => {
-  const MS_REFETCH_INTERVAL = 60000;
+  // How often to refresh that page’s data (in milliseconds)
+  const MS_REFETCH_INTERVAL = 60 * 1000;
 
   const [isLoading, setIsLoading] = useState<boolean>(false);
   const [isErrored, setIsErrored] = useState<boolean>(false);
@@ -141,6 +142,7 @@ const Home: NextPage<HomeData> = ({ valveMonitorConfig, err }) => {
                           <Button
                             type="primary"
                             danger
+                            disabled={isLoading}
                             onClick={clearAllAlarms}
                           >
                             Clear Alarms

--- a/valve-monitor/web-app/src/services/prisma-datastore/PrismaDataProvider.ts
+++ b/valve-monitor/web-app/src/services/prisma-datastore/PrismaDataProvider.ts
@@ -239,7 +239,7 @@ export class PrismaDataProvider implements DataProvider {
 
   // todo possibly transform this returned obj like we do for events and devices?
   async getLatestDeviceAlarm(deviceID: DeviceID): Promise<Notification> {
-    const latestAlarmFromDevice = await this.prisma.notification.findMany({
+    const latestAlarmFromDevice = await this.prisma.notification.findFirst({
       where: {
         AND: {
           type: "alarm",
@@ -249,9 +249,12 @@ export class PrismaDataProvider implements DataProvider {
           equals: deviceID.deviceUID,
         },
       },
-      take: -1,
+      orderBy: {
+        when: "desc",
+      },
     });
-    return latestAlarmFromDevice[0];
+
+    return latestAlarmFromDevice || undefined;
   }
 
   async getDevice(deviceID: DeviceID): Promise<Device> {

--- a/valve-monitor/web-app/src/services/prisma-datastore/PrismaDatastoreEventHandler.ts
+++ b/valve-monitor/web-app/src/services/prisma-datastore/PrismaDatastoreEventHandler.ts
@@ -104,7 +104,7 @@ export default class PrismaDatastoreEventHandler implements AppEventHandler {
           name,
           locationName,
           fleets: {
-            deleteMany: { fleetUID: { in: fleetUIDs } },
+            set: [],
             connectOrCreate: formatConnectedFleetData,
           },
           project: {

--- a/valve-monitor/web-app/src/styles/Home.module.scss
+++ b/valve-monitor/web-app/src/styles/Home.module.scss
@@ -18,6 +18,10 @@
     align-items: first baseline;
     justify-content: space-between;
   }
+
+  :global .ant-alert {
+    margin-top: 15px;
+  }
 }
 
 @media screen and (max-width: $breakpoints-sm) {


### PR DESCRIPTION
This looks to be the cause of the wrong alarm showing up in the app. The previous code did not order the alarms, so if multiple alarms for a device are in the table, you were not guaranteed to get the most recent one. This PR alters the Prisma code to sort by `when` descending.