### PR TITLE
Add firmware for NF10.

### DIFF
--- a/10-flow-rate-monitor/firmware/.gitignore
+++ b/10-flow-rate-monitor/firmware/.gitignore
@@ -1,0 +1,5 @@
+.pio
+.vscode/.browse.c_cpp.db*
+.vscode/c_cpp_properties.json
+.vscode/launch.json
+.vscode/ipch

--- a/10-flow-rate-monitor/firmware/.vscode/extensions.json
+++ b/10-flow-rate-monitor/firmware/.vscode/extensions.json
@@ -1,0 +1,10 @@
+{
+    // See http://go.microsoft.com/fwlink/?LinkId=827846
+    // for the documentation about the extensions.json format
+    "recommendations": [
+        "platformio.platformio-ide"
+    ],
+    "unwantedRecommendations": [
+        "ms-vscode.cpptools-extension-pack"
+    ]
+}

--- a/10-flow-rate-monitor/firmware/README.md
+++ b/10-flow-rate-monitor/firmware/README.md
@@ -1,0 +1,42 @@
+# Flow Rate Sensor
+
+This directory contains Arduino-based firmware for a flow rate measurement
+utility. The firmware source code is identical to the valve-monitor firmware in
+this repository. However, the Visual Studio Code project here sets the macro
+USE_VALVE to 0.
+
+## Requirements
+
+- Visual Studio Code with the [PlatformIO IDE](https://platformio.org/platformio-ide)
+installed.
+- [Notecard](https://blues.io/products/notecard/).
+- [Swan MCU](https://blues.io/products/swan/).
+- [Notecarrier F](https://blues.io/products/notecarrier/notecarrier-f/).
+- Male to male jumper wires.
+- A micro USB data cable.
+
+## Setup
+
+- [Plug the Notecard into the Notecarrier F](https://dev.blues.io/quickstart/notecard-quickstart/notecard-and-notecarrier-f/).
+- Plug the Swan into the Feather-compatible headers on the Notecarrier.
+- Connect the ATTN and F_D13 pins on the Notecarrier.
+- Connect the F_D6 pin of the Notecarrier to the signal pin of your flow rate
+meter.
+- Connect the Swan to your development machine with the micro USB cable.
+- Open Visual Studio Code and navigate to the PlatformIO menu using the icon
+on the leftmost side.
+- Select "Open" and open 10-flow-rate-monitor/firmware.
+- Edit main.cpp so to define a valid product UID:
+
+```C
+// Replace with your product UID.
+// #define PRODUCT_UID "com.my-company.my-name:my-project"
+```
+
+- In the Project Tasks pane of the PlatformIO view, click Build.
+- Hold down the BOOT button on the Swan, press and release the RST button, and
+release the BOOT button. The Swan is now ready to receive the firmware image
+from PlatformIO via the micro USB cable.
+- In the Project Tasks pane of the PlatformIO view, click Upload.
+- At the bottom of the VS Code window, click the tiny plug icon to open the
+serial console. You should see messages from the Swan being logged.

--- a/10-flow-rate-monitor/firmware/include/README
+++ b/10-flow-rate-monitor/firmware/include/README
@@ -1,0 +1,39 @@
+
+This directory is intended for project header files.
+
+A header file is a file containing C declarations and macro definitions
+to be shared between several project source files. You request the use of a
+header file in your project source file (C, C++, etc) located in `src` folder
+by including it, with the C preprocessing directive `#include'.
+
+```src/main.c
+
+#include "header.h"
+
+int main (void)
+{
+ ...
+}
+```
+
+Including a header file produces the same results as copying the header file
+into each source file that needs it. Such copying would be time-consuming
+and error-prone. With a header file, the related declarations appear
+in only one place. If they need to be changed, they can be changed in one
+place, and programs that include the header file will automatically use the
+new version when next recompiled. The header file eliminates the labor of
+finding and changing all the copies as well as the risk that a failure to
+find one copy will result in inconsistencies within a program.
+
+In C, the usual convention is to give header files names that end with `.h'.
+It is most portable to use only letters, digits, dashes, and underscores in
+header file names, and at most one dot.
+
+Read more about using header files in official GCC documentation:
+
+* Include Syntax
+* Include Operation
+* Once-Only Headers
+* Computed Includes
+
+https://gcc.gnu.org/onlinedocs/cpp/Header-Files.html

--- a/10-flow-rate-monitor/firmware/lib/README
+++ b/10-flow-rate-monitor/firmware/lib/README
@@ -1,0 +1,46 @@
+
+This directory is intended for project specific (private) libraries.
+PlatformIO will compile them to static libraries and link into executable file.
+
+The source code of each library should be placed in a an own separate directory
+("lib/your_library_name/[here are source files]").
+
+For example, see a structure of the following two libraries `Foo` and `Bar`:
+
+|--lib
+|  |
+|  |--Bar
+|  |  |--docs
+|  |  |--examples
+|  |  |--src
+|  |     |- Bar.c
+|  |     |- Bar.h
+|  |  |- library.json (optional, custom build options, etc) https://docs.platformio.org/page/librarymanager/config.html
+|  |
+|  |--Foo
+|  |  |- Foo.c
+|  |  |- Foo.h
+|  |
+|  |- README --> THIS FILE
+|
+|- platformio.ini
+|--src
+   |- main.c
+
+and a contents of `src/main.c`:
+```
+#include <Foo.h>
+#include <Bar.h>
+
+int main (void)
+{
+  ...
+}
+
+```
+
+PlatformIO Library Dependency Finder will find automatically dependent
+libraries scanning project source files.
+
+More information about PlatformIO Library Dependency Finder
+- https://docs.platformio.org/page/librarymanager/ldf.html

--- a/10-flow-rate-monitor/firmware/platformio.ini
+++ b/10-flow-rate-monitor/firmware/platformio.ini
@@ -11,11 +11,11 @@
 [env:bw_swan_r5]
 platform = ststm32
 board = bw_swan_r5
-build_flags = 
+build_flags =
 	-D PIO_FRAMEWORK_ARDUINO_ENABLE_CDC
-	-D USE_VALVE=1
+	-D USE_VALVE=0
 upload_protocol = dfu
 framework = arduino
-lib_deps = 
+lib_deps =
 	blues/Blues Wireless Notecard@^1.3.13
 debug_tool = stlink

--- a/10-flow-rate-monitor/firmware/src/main.cpp
+++ b/10-flow-rate-monitor/firmware/src/main.cpp
@@ -1,0 +1,1 @@
+../../../valve-monitor/firmware/src/main.cpp

--- a/10-flow-rate-monitor/firmware/test/README
+++ b/10-flow-rate-monitor/firmware/test/README
@@ -1,0 +1,11 @@
+
+This directory is intended for PlatformIO Test Runner and project tests.
+
+Unit Testing is a software testing method by which individual units of
+source code, sets of one or more MCU program modules together with associated
+control data, usage procedures, and operating procedures, are tested to
+determine whether they are fit for use. Unit testing finds problems early
+in the development cycle.
+
+More information about PlatformIO Unit Testing:
+- https://docs.platformio.org/en/latest/advanced/unit-testing/index.html


### PR DESCRIPTION
The firmware source code for NF9 and 10 is identical. NF10's main.cpp is just a symbolic link to NF9's main.cpp. Valve support is compiled in by defining the macro USE_VALVE to 1. It's compiled out by setting USE_VALVE to 0. The platform.ini build_flags set this macro accordingly for each project.
