### PR TITLE
chore: moving nf18 README to main folder, and two link fixes

### DIFF
--- a/18-temperature-and-humidity-monitor/README.md
+++ b/18-temperature-and-humidity-monitor/README.md
@@ -8,8 +8,8 @@ Monitor temperature and humidity and send alerts using a Notecard and a BME280 s
     - [Software](#software)
   - [Notehub Setup](#notehub-setup)
   - [Hardware Setup](#hardware-setup)
-  - [Notecard Firmware Setup](#software-setup)
-  - [Swan Firmware Setup](#software-setup)
+  - [Notecard Firmware Setup](#notecard-firmware-setup)
+  - [Swan Firmware Setup](#swan-firmware-setup)
   - [Operation](#operation)
     - [data.qo](#dataqo)
     - [alarm.qo](#alarmqo)
@@ -54,8 +54,8 @@ The Notecard should use [firmware version 3.5.1](https://dev.blues.io/notecard/n
 ## Swan Firmware Setup
 
 1. Open Visual Studio Code.
-2. Click the PlatformIO icon on the left hand side and open this "firmware" folder with Quick Access > PIO Home > Open > Open Project.
-3. Open the file src/main.cpp. Uncomment this line
+2. Click the PlatformIO icon on the left hand side and open this project's `firmware` folder with Quick Access > PIO Home > Open > Open Project.
+3. Open the file `src/main.cpp`. Uncomment this line
 
 ```c
 #define PRODUCT_UID "com.your-company:your-product-name"


### PR DESCRIPTION
This PR just moves nf18’s README from a firmware folder to the root of the project, just to be consistent with the other projects.