### PR TITLE
nf18: Remove sync from hub.set from Arduino firmware.

### DIFF
--- a/18-temperature-and-humidity-monitor/firmware/arduino/src/main.cpp
+++ b/18-temperature-and-humidity-monitor/firmware/arduino/src/main.cpp
@@ -295,7 +295,6 @@ void setup()
     }
     JAddStringToObject(req, "mode", "periodic");
     JAddNumberToObject(req, "outbound", OUTBOUND_SYNC_MINS);
-    JAddBoolToObject(req, "sync", true);
     notecard.sendRequest(req);
 
     // Send a note to _health.qo when USB power is lost or restored.


### PR DESCRIPTION
Documentation for the `sync` param:

> If in continuous mode, automatically and immediately sync each time an inbound
> Notefile change is detected on Notehub.

So it's irrelevant for periodic mode.
