### PR TITLE
Removed specific product UID from sense-hat-ref...

### DIFF
--- a/sense-hat-reference/src/main.cpp
+++ b/sense-hat-reference/src/main.cpp
@@ -11,7 +11,14 @@
 #define serialDebugOut Serial
 // Uncomment to view Note requests from the Host
 #define DEBUG_NOTECARD
-#define PRODUCT_UID "com.blues.sense_hat_sample"
+
+// Uncomment this line and replace com.your-company:your-product-name with your
+// ProductUID.
+// #define PRODUCT_UID "com.your-company:your-product-name"
+#ifndef PRODUCT_UID
+#define PRODUCT_UID ""
+#pragma message "PRODUCT_UID is not defined in this example. Please ensure your Notecard has a product identifier set before running this example or define it in code here. More details at https://bit.ly/product-uid"
+#endif
 
 #define UPDATE_PERIOD (15000) // (1000 * 60 * 5)
 #define VOLUME_UPDATE_PERIOD (1000)


### PR DESCRIPTION
Removed a reference to a specific product UID in sense-hat-reference main.cpp

# Problem Context
Specifc product UID in example file

## Changes
removed reference, and replaced with standard `#ifndef ` catch for the PRODUCT_UID



## Testing
None
