### PR TITLE
Retry hub.set in various apps' firmware.

### DIFF
--- a/09-valve-monitor/firmware/arduino/src/main.cpp
+++ b/09-valve-monitor/firmware/arduino/src/main.cpp
@@ -42,6 +42,11 @@
 #define APP_NAME "nf9"
 #endif
 
+// Timeout after HUB_SET_TIMEOUT seconds of retrying hub.set.
+#ifndef HUB_SET_TIMEOUT
+#define HUB_SET_TIMEOUT 5
+#endif
+
 struct AppState {
     uint32_t lastEnvVarPollMs;
     uint32_t monitorIntervalMs;
@@ -361,7 +366,9 @@ void setup()
     }
     JAddStringToObject(req, "mode", "continuous");
     JAddBoolToObject(req, "sync", true);
-    notecard.sendRequest(req);
+    // The hub.set request may fail if it's sent shortly after power up. We use
+    // sendRequestWithRetry to give it a chance to succeed.
+    notecard.sendRequestWithRetry(req, HUB_SET_TIMEOUT);
 
     // Disarm ATTN to clear any previous state before re-arming.
     req = notecard.newRequest("card.attn");

--- a/09-valve-monitor/firmware/zephyr/src/main.c
+++ b/09-valve-monitor/firmware/zephyr/src/main.c
@@ -41,6 +41,11 @@
 // leak warnings.
 #define LEAK_THRESHOLD 6
 
+// Timeout after HUB_SET_TIMEOUT seconds of retrying hub.set.
+#ifndef HUB_SET_TIMEOUT
+#define HUB_SET_TIMEOUT 5
+#endif
+
 // Uncomment the define below and replace com.your-company:your-product-name
 // with your ProductUID.
 // #define PRODUCT_UID "com.your-company:your-product-name"
@@ -617,7 +622,7 @@ void main(void)
     }
     JAddStringToObject(req, "mode", "continuous");
     JAddBoolToObject(req, "sync", true);
-    if (NoteRequest(req)) {
+    if (NoteRequestWithRetry(req, HUB_SET_TIMEOUT)) {
         printk("Notecard hub.set successful.\n");
     }
     else {

--- a/10-flow-rate-monitor/firmware/platformio.ini
+++ b/10-flow-rate-monitor/firmware/platformio.ini
@@ -14,9 +14,9 @@ board = bw_swan_r5
 build_flags =
 	-D PIO_FRAMEWORK_ARDUINO_ENABLE_CDC
 	-D USE_VALVE=0
-	-D APP_NAME="nf10"
+	-D APP_NAME="\"nf10\""
 upload_protocol = dfu
 framework = arduino
 lib_deps =
-	blues/Blues Wireless Notecard@^1.3.13
+	blues/Blues Wireless Notecard@^1.4.1
 debug_tool = stlink

--- a/10-flow-rate-monitor/firmware/src/main.cpp
+++ b/10-flow-rate-monitor/firmware/src/main.cpp
@@ -1,1 +1,1 @@
-../../../valve-monitor/firmware/src/main.cpp
+../../../09-valve-monitor/firmware/arduino/src/main.cpp

--- a/35-CAN-vehicle-monitor/firmware/platformio.ini
+++ b/35-CAN-vehicle-monitor/firmware/platformio.ini
@@ -14,4 +14,4 @@ board = adafruit_feather_m4_can
 framework = arduino
 lib_deps =
     adafruit/CAN Adafruit Fork@^1.2.1
-    blues/Blues Wireless Notecard@^1.3.18
+    blues/Blues Wireless Notecard@^1.4.1

--- a/35-CAN-vehicle-monitor/firmware/src/main.cpp
+++ b/35-CAN-vehicle-monitor/firmware/src/main.cpp
@@ -139,8 +139,8 @@ void setup() {
     JAddStringToObject(req, "mode", "continuous");
     JAddBoolToObject(req, "sync", true);
     // The hub.set request may fail if it's sent shortly after power up. We use
-    // NoteRequestWithRetry to give it a chance to succeed.
-    if (!NoteRequestWithRetry(req, HUB_SET_TIMEOUT)) {
+    // sendRequestWithRetry to give it a chance to succeed.
+    if (!notecard.sendRequestWithRetry(req, HUB_SET_TIMEOUT)) {
         notecard.logDebug("hub.set failed");
     }
 

--- a/scripts/build_pio_firmware.sh
+++ b/scripts/build_pio_firmware.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+
+#
+# This script builds all PlatformIO-based firmware in the repo.
+#
+
+script_dir=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+root_dir=$script_dir/..
+
+pio_app_dirs=(
+    "$root_dir/01-indoor-floor-level-tracker/firmware"
+    "$root_dir/04-low-power-digital-signage/firmware"
+    "$root_dir/08-power-quality-monitor/firmware"
+    "$root_dir/09-valve-monitor/firmware/arduino"
+    "$root_dir/10-flow-rate-monitor/firmware"
+    "$root_dir/11-generator-activity-monitor/firmware"
+    "$root_dir/12-remote-power-control/firmware"
+    "$root_dir/13-tool-usage-cycle-tracking/firmware"
+    "$root_dir/18-temperature-and-humidity-monitor/firmware/arduino"
+    "$root_dir/35-CAN-vehicle-monitor/firmware"
+)
+
+for app_dir in ${pio_app_dirs[@]}; do
+    echo "Building firmware in $app_dir..."
+
+    pio run --project-dir $app_dir
+    ret=$?
+    if [ $ret -ne 0 ]; then
+        printf "pio run failed (%d).\n" "$ret"
+        exit $ret
+    fi
+done
+
+echo "All PlatformIO-based firmware built successfully!"


### PR DESCRIPTION
This addresses a problem where the Notecard and host have just booted up and the Notecard isn't ready to receive the first request.

This change touched several different apps, so I added a script to build all these apps' firmware, which happen to all be PlatformIO-based. In doing this, I found some other problems:

- NF10 firmware was broken because the APP_NAME macro wasn't quoted. Also, the symlink to NF9's main.cpp was broken.
- NF10 and NF35 needed a newer version of note-arduino so they could use sendRequestWithRetry.