### PR TITLE
fix: .env.example syntax

### DIFF
--- a/09-valve-monitor/web-app/.env.example
+++ b/09-valve-monitor/web-app/.env.example
@@ -16,7 +16,7 @@ APP_ID="valve-monitor"
 
 ## Tunnel from Public Internet to local dev environment.
 # in effect: https://$SITE_SUBDOMAIN.loca.lt
-SITE_SUBDOMAIN="$(whoami)-$(APP_ID)"
+SITE_SUBDOMAIN="$(whoami)-${APP_ID}"
 ## Header
 NEXT_PUBLIC_COMPANY_NAME=''
 ## Footer


### PR DESCRIPTION
Switch from (parenthesis) to {curly braces} around `APP_ID`, so `.env` can be sourced by `dev.db.ephemeral.sh` without error.