### PR TITLE
NF34 CI fixes - platform has breaking changes

### DIFF
--- a/.github/workflows/nf34-ci.yml
+++ b/.github/workflows/nf34-ci.yml
@@ -30,6 +30,8 @@ jobs:
         # The list of all available versions can be found here: https://raw.githubusercontent.com/actions/python-versions/main/versions-manifest.json    
         #
         # see: https://github.com/actions/setup-python/blob/main/docs/advanced-usage.md#using-setup-python-with-a-self-hosted-runner 
+        # Instead we use the system version of python which has been set to 3.11.4
+
       - name: Create and start virtual environment
         run: |
           python3 -m venv venv
@@ -40,9 +42,10 @@ jobs:
         run: |
             pip install cffi platformio
             echo $PLATFORMIO_BUILD_FLAGS
+            pio --version
             pio remote -a "$PLATFORMIO_AGENT" run -d "$PROJECT_DIR" -t clean
 
-            # cannot use --force-remote to build on the agent because environment variables are not propagated
+            # cannot use --force-remote to build on the agent's pio installation because environment variables are not propagated
             # used to have -t clean -t upload which worked with --force-remote, but not with a local build
             pio remote -a "$PLATFORMIO_AGENT" run -d "$PROJECT_DIR" --upload-port "$NF34_PORT_STLINK" -t upload
 

--- a/.github/workflows/nf34-ci.yml
+++ b/.github/workflows/nf34-ci.yml
@@ -3,6 +3,7 @@ on:
   pull_request:
     paths:
       - "34-cellular-modbus-client/**"
+      - ".github/workflows/nf34-ci.yml"
   workflow_dispatch: # allow the job to be run manually
 
 jobs:

--- a/.github/workflows/nf34-ci.yml
+++ b/.github/workflows/nf34-ci.yml
@@ -37,7 +37,7 @@ jobs:
       - name: Build PlatformIO Project
         # NF34_PORT_xxx are defined in the `.env` file in the actions runner service on the self hosted runner
         run: |
-            pip install platformio
+            pip install cffi platformio
             echo $PLATFORMIO_BUILD_FLAGS
             pio remote -a "$PLATFORMIO_AGENT" run -d "$PROJECT_DIR" -t clean
 


### PR DESCRIPTION
something has changed. pio fails on python 3.10. Upgraded to 3.11.4 on the runner and added missing dependency `cffi`.

# Problem Context

## Changes

## Screenshot (if applicable)

## Testing

Unit / integration / e2e tests?
Steps to test manually?
Any other sorts of testing notes to include?

## Any other related PRs

## Ticket(s)
