### PR TITLE
chore: adding back accelerator video demos

### DIFF
--- a/06-parking-lot-help-request/README.md
+++ b/06-parking-lot-help-request/README.md
@@ -4,6 +4,8 @@ Host-free low latency notification system to alert attendants in a parking lot o
 
 ![](images/banner.png)
 
+> [Watch a video of this project in action.](https://www.youtube.com/watch?v=uhwdbYxxles)
+
 To run this project yourself you'll need to:
 
 * [Purchase the necessary hardware and configure it](#hardware).

--- a/27-cellular-connected-electronic-kiosk/README.md
+++ b/27-cellular-connected-electronic-kiosk/README.md
@@ -2,6 +2,8 @@
 
 A cellular-based solution for downloading resources for an electronic kiosk display without an Internet connection, using a simple Python script.
 
+> [Watch a video of this project in action.](https://www.youtube.com/watch?v=_41cecWfEJ8)
+
 In an effort to keep the required download size for the Raspberry Pi small, the hardware and Notehub cloud setup is covered in this repo, and the code required to run the app on the Pi and a sample web app to demonstrate how to zip up a project are located in a [separate repository](https://github.com/blues/accelerators-cellular-connected-electronic-kiosk).
 
 To run this project you'll need to:


### PR DESCRIPTION
Quick one to restore the two video links we temporarily removed.

Ticket: https://trello.com/c/RTdGPWsV/539-restore-videos-in-accelerator-readmes-for-parking-lot-help-request-and-cellular-connected-electronic-kiosk