### PR TITLE
chore: update card.temp from seconds to minutes

### DIFF
--- a/17-refrigerator-monitor/README.md
+++ b/17-refrigerator-monitor/README.md
@@ -55,7 +55,7 @@ Turning on track mode will augment the environmental data with pressure and humi
 Next, paste this command into the in-browser terminal:
 
 ```json
-{ "req": "card.temp", "seconds": 180 }
+{ "req": "card.temp", "minutes": 3 }
 ```
 
 This will cause the Notecard to push a note to the `_temp.qo` Notefile with environmental data every 3 minutes. You can modify this interval to suit your application's needs. Note that this matches the 3 minute settings we specified for `outbound` in the `hub.set` request above.

--- a/17-refrigerator-monitor/config.json
+++ b/17-refrigerator-monitor/config.json
@@ -1,4 +1,4 @@
 { "req": "hub.set", "mode": "periodic", "outbound": 3, "product": "com.your-company:your-product-name", "sn": "fridge-location", "body":{"app":"nf17"} }
 { "req": "card.aux", "mode":"track" }
-{ "req": "card.temp", "seconds": 180 }
+{ "req": "card.temp", "minutes": 3 }
 { "req": "card.voltage", "mode": "lipo", "usb": true, "alert": true, "sync": true }


### PR DESCRIPTION
# Problem Context

Full context in https://trello.com/c/hevjvCsq/593-remove-seconds-from-cardtemp-doc. Short version is we’re now recommending people use `minutes` for `card.temp` (instead of `seconds`), and this PR updates the one accelerator that was using `seconds`.
