### PR TITLE
chore: quick link update

### DIFF
--- a/28-door-state-monitor/README.md
+++ b/28-door-state-monitor/README.md
@@ -93,4 +93,4 @@ We’d love to hear about you and your project on the [Blues Community Forum](ht
 
 ## Additional Resources
 
-* [Notecard Lora Datasheet](https://dev.blues.io/datasheets/notecard-datasheet/note-lora/)
+* [Notecard Lora Datasheet](https://dev.blues.io/datasheets/notecard-datasheet/note-lora-v2-1/)


### PR DESCRIPTION
This link doesn’t exist yet, but will shortly, and this needs to update for the blues.dev build to pass.